### PR TITLE
Set custom PROGRAMMER and PORT (on cli) without modifying Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,11 +81,11 @@ CORE=core
 # PROGRAMMER CONFIGURATION
 # ------------------------
 
-PROGRAMMER=usbtiny
-PORT=
+PROGRAMMER?=usbtiny
+PORT?=/dev/ttyUSB0
 
 AVRDUDE=avrdude
-AVRDUDE_FLAGS= -c $(PROGRAMMER)
+AVRDUDE_FLAGS= -P $(PORT) -c $(PROGRAMMER)
 
 # ----------------
 # ASSEMBLER TO USE


### PR DESCRIPTION
Hello nfz, I've changed PROGRAMMER and PORT to be assigned the value in the Makefile only if there is no value assigned on the command line:

    make atmega328p PROGRAMMER=buspirate PORT=/dev/ttyUSB0

This way I can I can use my buspirate to flash without changing the Makefile back to usbtiny everytime I would want to commit changes for upstream.